### PR TITLE
Quit warnings caused for deprecations in Swift 2.2

### DIFF
--- a/SwiftAlertView/SwiftAlertView.swift
+++ b/SwiftAlertView/SwiftAlertView.swift
@@ -204,11 +204,11 @@ public class SwiftAlertView: UIView {
             dimView = UIView(frame: view.bounds)
             dimView!.backgroundColor = UIColor(white: 0, alpha: CGFloat(dimAlpha))
             view.addSubview(dimView!)
-            let recognizer = UITapGestureRecognizer(target: self, action: Selector("outsideClicked:"))
+            let recognizer = UITapGestureRecognizer(target: self, action: #selector(SwiftAlertView.outsideClicked(_:)))
             dimView!.addGestureRecognizer(recognizer)
         }
         
-        if delegate?.respondsToSelector(Selector("willPresentAlertView:")) == true {
+        if delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.willPresentAlertView(_:))) == true {
             delegate?.willPresentAlertView!(self)
         }
         
@@ -222,7 +222,7 @@ public class SwiftAlertView: UIView {
                 self.transform = CGAffineTransformIdentity
                 self.alpha = 1
                 }) { (finished) -> Void in
-                    if self.delegate?.respondsToSelector(Selector("didPresentAlertView:")) == true {
+                    if self.delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.didPresentAlertView(_:))) == true {
                         self.delegate?.didPresentAlertView!(self)
                     }
             };
@@ -231,7 +231,7 @@ public class SwiftAlertView: UIView {
             UIView.animateWithDuration(appearTime, delay: 0, options: UIViewAnimationOptions.CurveEaseInOut, animations: { () -> Void in
                 self.alpha = 1
             }, completion: { (finished) -> Void in
-                if self.delegate?.respondsToSelector(Selector("didPresentAlertView:")) == true {
+                if self.delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.didPresentAlertView(_:))) == true {
                     self.delegate?.didPresentAlertView!(self)
                 }
             })
@@ -241,7 +241,7 @@ public class SwiftAlertView: UIView {
             UIView.animateWithDuration(appearTime, delay: 0, options: UIViewAnimationOptions.CurveEaseInOut, animations: { () -> Void in
                 self.frame = tempFrame
                 }, completion: { (finished) -> Void in
-                    if self.delegate?.respondsToSelector(Selector("didPresentAlertView:")) == true {
+                    if self.delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.didPresentAlertView(_:))) == true {
                         self.delegate?.didPresentAlertView!(self)
                     }
             })
@@ -251,7 +251,7 @@ public class SwiftAlertView: UIView {
             UIView.animateWithDuration(appearTime, delay: 0, options: UIViewAnimationOptions.CurveEaseInOut, animations: { () -> Void in
                 self.frame = tempFrame
                 }, completion: { (finished) -> Void in
-                    if self.delegate?.respondsToSelector(Selector("didPresentAlertView:")) == true {
+                    if self.delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.didPresentAlertView(_:))) == true {
                         self.delegate?.didPresentAlertView!(self)
                     }
             })
@@ -260,7 +260,7 @@ public class SwiftAlertView: UIView {
     
     // programmatically dismiss the alert view
     public func dismiss() {
-        if self.delegate?.respondsToSelector(Selector("willDismissAlertView:")) == true {
+        if self.delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.willDismissAlertView(_:))) == true {
             self.delegate?.willDismissAlertView!(self)
         }
         
@@ -278,7 +278,7 @@ public class SwiftAlertView: UIView {
                 self.alpha = 0
                 }) { (finished) -> Void in
                     self.removeFromSuperview()
-                    if self.delegate?.respondsToSelector(Selector("didDismissAlertView:")) == true {
+                    if self.delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.didDismissAlertView(_:))) == true {
                         self.delegate?.didDismissAlertView!(self)
                     }
             }
@@ -288,7 +288,7 @@ public class SwiftAlertView: UIView {
                 self.alpha = 0
                 }) { (finished) -> Void in
                     self.removeFromSuperview()
-                    if self.delegate?.respondsToSelector(Selector("didDismissAlertView:")) == true {
+                    if self.delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.didDismissAlertView(_:))) == true {
                         self.delegate?.didDismissAlertView!(self)
                     }
             }
@@ -297,7 +297,7 @@ public class SwiftAlertView: UIView {
                 self.frame = CGRectMake(self.frame.origin.x, self.superview!.frame.size.height + 10, self.frame.size.width, self.frame.size.height)
                 }) { (finished) -> Void in
                     self.removeFromSuperview()
-                    if self.delegate?.respondsToSelector(Selector("didDismissAlertView:")) == true {
+                    if self.delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.didDismissAlertView(_:))) == true {
                         self.delegate?.didDismissAlertView!(self)
                     }
             }
@@ -306,7 +306,7 @@ public class SwiftAlertView: UIView {
                 self.frame = CGRectMake(self.superview!.frame.size.width + 10, self.frame.origin.y, self.frame.size.width, self.frame.size.height)
                 }) { (finished) -> Void in
                     self.removeFromSuperview()
-                    if self.delegate?.respondsToSelector(Selector("didDismissAlertView:")) == true {
+                    if self.delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.didDismissAlertView(_:))) == true {
                         self.delegate?.didDismissAlertView!(self)
                     }
             }
@@ -439,7 +439,7 @@ public class SwiftAlertView: UIView {
         var i = 0
         for button in buttons {
             button.tag = i
-            i++
+            i += 1
             button.backgroundColor = UIColor.clearColor()
             button.setTitleColor(buttonTitleColor, forState: UIControlState.Normal)
             if button.tag == cancelButtonIndex {
@@ -462,13 +462,13 @@ public class SwiftAlertView: UIView {
         var i = 0
         for button in buttons {
             button.tag = i
-            i++
+            i += 1
             
             if !buttonTitleColor.isEqual(UIColor(red: 0, green: 0.478431, blue: 1, alpha: 1)) {
                 button.setTitleColor(buttonTitleColor, forState: UIControlState.Normal)
             }
             
-            button.addTarget(self, action: Selector("buttonClicked:"), forControlEvents: UIControlEvents.TouchUpInside)
+            button.addTarget(self, action: #selector(SwiftAlertView.buttonClicked(_:)), forControlEvents: UIControlEvents.TouchUpInside)
         }
         
         if title != nil {
@@ -508,10 +508,9 @@ public class SwiftAlertView: UIView {
         } else {
             viewHeight = topPartHeight + buttonHeight * Double(buttons.count)
             var j = 1
-            for var i = buttons.count - 1; i >= 0; i = i - 1 {
-                let button = buttons[i]
+            for button in buttons.reverse() {
                 button.frame = CGRect(x: 0, y: viewHeight-buttonHeight*Double(j), width: viewWidth, height: buttonHeight)
-                j++
+                j += 1
                 if hideSeparator == false {
                     let lineView = UIView(frame: CGRect(x: 0, y: Double(button.frame.origin.y), width: viewWidth, height: kSeparatorWidth))
                     lineView.backgroundColor = separatorColor
@@ -537,7 +536,7 @@ public class SwiftAlertView: UIView {
         
         let buttonIndex = button.tag
         
-        if delegate?.respondsToSelector(Selector("alertView:clickedButtonAtIndex:")) == true {
+        if delegate?.respondsToSelector(#selector(SwiftAlertViewDelegate.alertView(_:clickedButtonAtIndex:))) == true {
             delegate?.alertView!(self, clickedButtonAtIndex: buttonIndex)
         }
         


### PR DESCRIPTION
Quit warnings caused for deprecations in Swift 2.2 previous to suppression in Swift 3, the changes are:
- Use of #selector instead of Selector
- Change ++ with +=1
- Change for traditional with for in