### PR TITLE
Hide and restore keyboard when alert is shown as native UIAlertViewController behavior

### DIFF
--- a/SwiftAlertView/SwiftAlertView.swift
+++ b/SwiftAlertView/SwiftAlertView.swift
@@ -102,6 +102,8 @@ public class SwiftAlertView: UIView {
     
     
     // MARK: Private Properties
+    
+    private var firstResponderView: UIView?
     private var contentView: UIView?
     private var buttons = [UIButton]()
     private var backgroundImageView: UIImageView?
@@ -190,6 +192,11 @@ public class SwiftAlertView: UIView {
     // show the alert view at center of screen
     public func show() {
         if let window: UIWindow = UIApplication.sharedApplication().keyWindow {
+            let rootVC = UIApplication.sharedApplication().keyWindow?.rootViewController
+            if let view = rootVC!.view.retrieveFirstResponder() {
+                firstResponderView = view
+                firstResponderView?.resignFirstResponder()
+            }
             show(window)
         }
     }
@@ -318,8 +325,7 @@ public class SwiftAlertView: UIView {
             }
         }
 
-
-
+        firstResponderView?.becomeFirstResponder()
     }
     
     // declare the closure to handle clicked button event

--- a/SwiftAlertView/UIView+Extensions.swift
+++ b/SwiftAlertView/UIView+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  UIView+Extensions.swift
+//  SwiftAlertViewDemo
+//
+//  Created by Eugene Goloboyar on 5/23/16.
+//  Copyright © 2016 Dinh Quan. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIView {
+    
+    func retrieveFirstResponder() -> UIView? {
+        if self.isFirstResponder() {
+            return self
+        }
+        
+        for subview in self.subviews {
+            if let firstResponderView = subview.retrieveFirstResponder() {
+                return firstResponderView
+            }
+        }
+        
+        return nil
+    }
+    
+}

--- a/SwiftAlertViewDemo/SwiftAlertViewDemo.xcodeproj/project.pbxproj
+++ b/SwiftAlertViewDemo/SwiftAlertViewDemo.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		F4CA4BBE1B90B0C1004A12C1 /* SwiftAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CA4BBD1B90B0C1004A12C1 /* SwiftAlertView.swift */; };
 		F4CA4BC01B90B0FF004A12C1 /* Marker Felt.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F4CA4BBF1B90B0FF004A12C1 /* Marker Felt.ttf */; };
 		F4CA4BC21B90B108004A12C1 /* CustomView.xib in Resources */ = {isa = PBXBuildFile; fileRef = F4CA4BC11B90B108004A12C1 /* CustomView.xib */; };
+		FA7382691CF348CE003377C4 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7382681CF348CE003377C4 /* UIView+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		F4CA4BBD1B90B0C1004A12C1 /* SwiftAlertView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftAlertView.swift; sourceTree = "<group>"; };
 		F4CA4BBF1B90B0FF004A12C1 /* Marker Felt.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Marker Felt.ttf"; sourceTree = "<group>"; };
 		F4CA4BC11B90B108004A12C1 /* CustomView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CustomView.xib; sourceTree = "<group>"; };
+		FA7382681CF348CE003377C4 /* UIView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +87,7 @@
 			isa = PBXGroup;
 			children = (
 				F4CA4BBD1B90B0C1004A12C1 /* SwiftAlertView.swift */,
+				FA7382681CF348CE003377C4 /* UIView+Extensions.swift */,
 			);
 			name = SwiftAlertView;
 			path = ../SwiftAlertView;
@@ -166,6 +169,7 @@
 			files = (
 				F4CA4BBE1B90B0C1004A12C1 /* SwiftAlertView.swift in Sources */,
 				F4CA4B9F1B90B069004A12C1 /* ViewController.swift in Sources */,
+				FA7382691CF348CE003377C4 /* UIView+Extensions.swift in Sources */,
 				F4CA4B9D1B90B069004A12C1 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Hide and restore keyboard by looking for first responder in all views.
It would be useful when alert is displayed to indicate error but keyboard still displayed and user shouldn't be available to enter smth.